### PR TITLE
Fix char-range typo [a-zA-z] -> [a-zA-Z] in compounds parser

### DIFF
--- a/compounds/AB_AP57/parse.py
+++ b/compounds/AB_AP57/parse.py
@@ -134,7 +134,7 @@ def write_cpds1(cpdentries,fileout):
  for e in cpdentries:
   ncpds = ncpds + len(e.cpds)
   hw = e.hw
-  hw = re.sub(r'[^a-zA-z].*$','',hw)  # remove 'comments'
+  hw = re.sub(r'[^a-zA-Z].*$','',hw)  # remove 'comments'
   a = []
   for e in e.cpds:
    pfx,sfx = e


### PR DESCRIPTION
## What

Fixes a character-range typo in `compounds/AB_AP57/parse.py:137`:

```diff
- hw = re.sub(r'[^a-zA-z].*$','',hw)  # remove 'comments'
+ hw = re.sub(r'[^a-zA-Z].*$','',hw)  # remove 'comments'
```

## Why

The range `A-z` is not `A-Z` + `a-z` — it also spans the six ASCII characters between `Z` and `a`: `` [ \ ] ^ _ ` ``. So `[^a-zA-z]` treated those punctuation characters as 'letters' and failed to strip them when trimming trailing comments from a headword. CodeQL flags this as `py/overly-large-range`. The intended class is `[^a-zA-Z]`.

One-character correctness fix; also clears the open code-scanning alert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)