### PR TITLE
Add SEO/UX landing page for GitHub Pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,104 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>The Practical Sanskrit–English Dictionary (1890) (AP90) · Cologne Digital Sanskrit Lexicon</title>
+<meta name="description" content="The original 1890 edition of Apte&#x27;s Practical Sanskrit–English Dictionary, before the later revision — a widely cited Sanskrit–English reference.">
+<link rel="canonical" href="https://sanskrit-lexicon.github.io/AP90/">
+<meta name="theme-color" content="#1f78b4">
+<meta name="author" content="Vaman Shivram Apte">
+<meta name="robots" content="index,follow">
+<meta property="og:type" content="website">
+<meta property="og:site_name" content="Cologne Digital Sanskrit Lexicon">
+<meta property="og:locale" content="en">
+<meta property="og:title" content="The Practical Sanskrit–English Dictionary (1890) (AP90)">
+<meta property="og:description" content="The original 1890 edition of Apte&#x27;s Practical Sanskrit–English Dictionary, before the later revision — a widely cited Sanskrit–English reference.">
+<meta property="og:url" content="https://sanskrit-lexicon.github.io/AP90/">
+<meta property="og:image" content="https://sanskrit-lexicon.github.io/cdsl-card.png">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta property="og:image:alt" content="Cologne Digital Sanskrit Lexicon">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="The Practical Sanskrit–English Dictionary (1890) (AP90)">
+<meta name="twitter:description" content="The original 1890 edition of Apte&#x27;s Practical Sanskrit–English Dictionary, before the later revision — a widely cited Sanskrit–English reference.">
+<meta name="twitter:image" content="https://sanskrit-lexicon.github.io/cdsl-card.png">
+<script type="application/ld+json">
+{"@context":"https://schema.org","@type":"Book","name":"The Practical Sanskrit–English Dictionary (1890)","alternateName":"AP90","inLanguage":"sa","publisher":{"@type":"Organization","name":"Cologne Digital Sanskrit Lexicon"},"url":"https://sanskrit-lexicon.github.io/AP90/","isAccessibleForFree":true,"license":"https://creativecommons.org/licenses/by-sa/4.0/"}
+</script>
+<style>
+  :root { --ink:#1b2a38; --muted:#5a6b7a; --accent:#1f78b4; --bg:#f7f9fb; --card:#fff; --line:#e2e8ee; }
+  * { box-sizing:border-box; }
+  html { -webkit-text-size-adjust:100%; }
+  body { margin:0; font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;
+    color:var(--ink); background:var(--bg); line-height:1.6; }
+  a { color:var(--accent); }
+  .wrap { max-width:760px; margin:0 auto; padding:0 20px; }
+  header.top { border-bottom:1px solid var(--line); background:var(--card); }
+  header.top .wrap { display:flex; align-items:center; gap:.5rem; height:56px; font-size:.95rem; }
+  header.top a { color:var(--muted); text-decoration:none; font-weight:600; }
+  .hero { background:linear-gradient(160deg,#1e2f40,#2d4e6e); color:#f4f7fa; padding:56px 0 48px; }
+  .badge { display:inline-block; font-weight:700; letter-spacing:.08em; font-size:.8rem;
+    background:rgba(255,255,255,.14); color:#cfe3f2; padding:.35rem .7rem; border-radius:999px; }
+  .hero h1 { font-family:Georgia,"Times New Roman",serif; font-size:2.1rem; line-height:1.2; margin:.9rem 0 .5rem; }
+  .hero .sub { color:#b7cddf; font-size:1.05rem; margin:0 0 1.2rem; }
+  .hero p.desc { color:#dbe6f0; margin:0; max-width:62ch; }
+  .cta { display:flex; flex-wrap:wrap; gap:.7rem; margin:1.6rem 0 0; }
+  .btn { display:inline-block; padding:.7rem 1.1rem; border-radius:8px; text-decoration:none; font-weight:600; font-size:.95rem; }
+  .btn.primary { background:#4aa3df; color:#0b1b28; }
+  .btn.ghost { background:rgba(255,255,255,.10); color:#eaf2f8; border:1px solid rgba(255,255,255,.25); }
+  main { padding:40px 0 20px; }
+  .facts { display:grid; grid-template-columns:repeat(auto-fit,minmax(150px,1fr)); gap:1px;
+    background:var(--line); border:1px solid var(--line); border-radius:10px; overflow:hidden; margin:0 0 28px; }
+  .facts div { background:var(--card); padding:14px 16px; }
+  .facts dt { font-size:.72rem; text-transform:uppercase; letter-spacing:.06em; color:var(--muted); }
+  .facts dd { margin:.2rem 0 0; font-weight:600; }
+  section h2 { font-size:1.15rem; margin:1.8rem 0 .5rem; }
+  .note { color:var(--muted); font-size:.95rem; }
+  footer { border-top:1px solid var(--line); background:var(--card); margin-top:32px; }
+  footer .wrap { padding:22px 20px; color:var(--muted); font-size:.9rem; }
+  footer a { color:var(--muted); }
+  @media (max-width:520px) { .hero h1 { font-size:1.7rem; } }
+</style>
+</head>
+<body>
+<header class="top"><div class="wrap"><a href="https://sanskrit-lexicon.github.io/">← Cologne Digital Sanskrit Lexicon</a></div></header>
+<div class="hero"><div class="wrap">
+  <span class="badge">AP90</span>
+  <h1>The Practical Sanskrit–English Dictionary (1890)</h1>
+  <p class="sub">Vaman Shivram Apte · Poona, 1890</p>
+  <p class="desc">The original 1890 edition of Apte's Practical Sanskrit–English Dictionary, before the later revision — a widely cited Sanskrit–English reference.</p>
+  <div class="cta">
+    <a class="btn primary" href="https://www.sanskrit-lexicon.uni-koeln.de/scans/AP90Scan/2020/web/webtc/indexcaller.php">Browse the dictionary →</a>
+    <a class="btn ghost" href="https://github.com/sanskrit-lexicon/AP90">Source &amp; corrections (GitHub)</a>
+    <a class="btn ghost" href="https://sanskrit-lexicon.github.io/">All dictionaries</a>
+  </div>
+</div></div>
+<main><div class="wrap">
+  <dl class="facts">
+    <div><dt>Abbreviation</dt><dd>AP90</dd></div>
+    <div><dt>Direction</dt><dd>Sanskrit → English</dd></div>
+    <div><dt>First published</dt><dd>1890</dd></div>
+    <div><dt>Digitised by</dt><dd>CDSL</dd></div>
+  </dl>
+  <section>
+    <h2>About this edition</h2>
+    <p class="note">This is the digital home of the <strong>The Practical Sanskrit–English Dictionary (1890)</strong> (AP90) within the
+    <a href="https://www.sanskrit-lexicon.uni-koeln.de/">Cologne Digital Sanskrit Lexicon</a> (CDSL),
+    a volunteer project that digitises, corrects, and openly publishes the foundational Sanskrit
+    dictionaries as citable, reproducible data. Corrections are tracked as change files in this
+    repository; the searchable text is served on the Cologne site.</p>
+    <h2>Use &amp; reuse</h2>
+    <p class="note">Dictionary data is released under
+    <a href="https://creativecommons.org/licenses/by-sa/4.0/">CC BY-SA 4.0</a> unless noted otherwise.
+    Report errors or contribute corrections via the
+    <a href="https://github.com/sanskrit-lexicon/AP90/issues">GitHub issue tracker</a>.</p>
+  </section>
+</div></main>
+<footer><div class="wrap">
+  Part of the <a href="https://sanskrit-lexicon.github.io/">Cologne Digital Sanskrit Lexicon</a> ·
+  <a href="https://www.sanskrit-lexicon.uni-koeln.de/">sanskrit-lexicon.uni-koeln.de</a> ·
+  <a href="https://github.com/sanskrit-lexicon">GitHub</a>
+</div></footer>
+</body>
+</html>


### PR DESCRIPTION
Adds a self-contained, mobile-friendly landing page (`index.html`) with full SEO (canonical, Open Graph, Twitter `summary_large_image`, JSON-LD `Book`) and a clean hero linking to the live dictionary on the Cologne site, the source repo, and the CDSL hub. `og:image` is the shared card at the org root. No dependencies, no build step.

Part of an org-wide pass giving every dictionary repo an optimised landing page. GitHub Pages will be enabled on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)