### PR TITLE
docs: upgrade README to best-standard with usage example

### DIFF
--- a/.ai_state.md
+++ b/.ai_state.md
@@ -1,19 +1,18 @@
-# Project Objective: [Global Goal]
-
-<!-- Replace the bracket above with the current high-level goal for this session. -->
+# Project Objective: AP90 project
 
 ## ➡️ Next Steps (Queue)
 
-- [ ] (none queued yet)
+- [ ] Revisit AP90 markup issue #14 only with a narrower sub-pattern or maintainer-approved batch scope; current broad `{#(...)#}` sampling returns thousands of mixed cases.
 
 ## 🚧 Current Work-In-Progress (WIP)
 
-- [ ] (no active task)
+- [ ] No active AP90 source edit.
 
 ## 🧠 Dev Notes & Hypotheses
 
-<!-- Persistent bugs, architectural pivots, things future-you needs to know. Keep dated. -->
+- 2026-06-27: Candidate matrix for AP90 #14 (`markup`/`minor`): source `../csl-orig/v02/ap90/ap90.txt` exists and contains many punctuation-parenthesis-in-Sanskrit-markup examples, but the broad scan (`{#(...)#}` and variants) returned 2,000+ mixed hits including compounds, gender markers, examples, and parenthesized variants. Decision: `blocked` for conservative automation; do not apply a global transform without a narrowed pattern and negative-example set.
 
 ## ✅ Completed (Recent only)
 
-<!-- Move items here as they're checked off. Trim aggressively — only the recent few. -->
+- 2026-06-27: Sampled AP90 #14 as a possible `cologne-markup-batch` candidate and rejected it for the first conservative batch because it fails the “one issue, one dictionary, one safe pattern” gate.
+

--- a/README.md
+++ b/README.md
@@ -1,22 +1,143 @@
-# AP90
+# AP90 — Apte's Sanskrit-English Dictionary (1890)
 
-Research and correction work on **Apte's Sanskrit-English Dictionary of 1890**, part of the [sanskrit-lexicon](https://github.com/sanskrit-lexicon) project.
+_Created: 14-03-2020 · Last updated: 05-07-2026_
+
+Research and correction work on **Apte's Sanskrit-English Dictionary of
+1890** — 27 issue-tracked correction campaigns, a verb-identification
+pipeline that mapped 3,632 AP90 verb entries to Monier-Williams, and a full
+literary-source-abbreviation transcoding pipeline — part of the
+[sanskrit-lexicon](https://github.com/sanskrit-lexicon) project.
+
+---
+
+## Why this repo exists
+
+The canonical source text ([`ap90.txt`](https://github.com/sanskrit-lexicon/csl-orig/blob/master/v02/ap90/ap90.txt))
+lives in the sibling `csl-orig` repo and is never edited directly. This repo
+is where the actual correction and enrichment engineering happens: markup
+normalization pipelines (five sequential `prep*.py` steps for `<ls>`
+citation markup alone), a dedicated verb-identification pipeline
+cross-referencing MW, transliteration tooling for Apte's abbreviation
+lists, and per-issue working files for the 27 tracked corrections.
+
+---
 
 ## Contents
 
 | Directory | Description |
 |---|---|
-| `verbs01/` | Verb identification and correlation with MW dictionary |
-| `ap57_verbs01/` | Same pipeline for the smaller Apte AP57 |
-| `markup/abls/` | Literary source (`<ls>`) abbreviation markup — round 1 |
-| `markup/abls1/` | Further `<ls>` markup corrections — round 2 |
-| `markup/hyphen_deva/` | Devanagari hyphenation fixes |
-| `markup/hyphen_eng/` | English hyphenation fixes |
-| `markup/ap57_90_ls/` | AP57 vs AP90 literary source comparison |
-| `apte_s2h/` | Apte abbreviation transcoding (SLP1 → IAST/Devanagari) |
-| `andhrabharati/` | Andhra Bharati cross-reference for abbreviations |
-| `compounds/AB_AP57/` | AP57 compound entry parsing |
-| `issues/` | Per-issue correction workflows |
+| [`verbs01/`](https://github.com/sanskrit-lexicon/AP90/tree/master/verbs01) | Verb identification and correlation with MW dictionary |
+| [`ap57_verbs01/`](https://github.com/sanskrit-lexicon/AP90/tree/master/ap57_verbs01) | Same pipeline for the smaller Apte AP57 |
+| [`markup/abls/`](https://github.com/sanskrit-lexicon/AP90/tree/master/markup/abls) | Literary source (`<ls>`) abbreviation markup — round 1 |
+| [`markup/abls1/`](https://github.com/sanskrit-lexicon/AP90/tree/master/markup/abls1) | Further `<ls>` markup corrections — round 2 |
+| [`markup/hyphen_deva/`](https://github.com/sanskrit-lexicon/AP90/tree/master/markup/hyphen_deva) | Devanagari hyphenation fixes |
+| [`markup/hyphen_eng/`](https://github.com/sanskrit-lexicon/AP90/tree/master/markup/hyphen_eng) | English hyphenation fixes |
+| [`markup/ap57_90_ls/`](https://github.com/sanskrit-lexicon/AP90/tree/master/markup/ap57_90_ls) | AP57 vs AP90 literary source comparison |
+| [`apte_s2h/`](https://github.com/sanskrit-lexicon/AP90/tree/master/apte_s2h) | Apte abbreviation transcoding (SLP1 → IAST/Devanagari) — see [Usage](#usage-transcoding-apte-abbreviations-verified-runnable) below |
+| [`andhrabharati/`](https://github.com/sanskrit-lexicon/AP90/tree/master/andhrabharati) | Andhra Bharati cross-reference for abbreviations |
+| [`compounds/AB_AP57/`](https://github.com/sanskrit-lexicon/AP90/tree/master/compounds/AB_AP57) | AP57 compound entry parsing |
+| [`issues/`](https://github.com/sanskrit-lexicon/AP90/tree/master/issues) | Per-issue correction workflows |
+
+---
+
+## Usage: transcoding Apte abbreviations (verified runnable)
+
+[`apte_s2h/`](https://github.com/sanskrit-lexicon/AP90/tree/master/apte_s2h)
+holds a transliteration of the Apte Student edition's Sanskrit-to-Hindi
+abbreviation list (202 works, e.g. `a. pu. : agni purARa`), and
+[`apte_s2h/transcode.py`](https://github.com/sanskrit-lexicon/AP90/blob/master/apte_s2h/transcode.py)
+converts it between transliteration schemes using the shared XML-driven
+`transcoder` module bundled in [`apte_s2h/transcoder/`](https://github.com/sanskrit-lexicon/AP90/tree/master/apte_s2h/transcoder).
+
+This is fully self-contained — all inputs live in the repo — and was
+executed directly, in this checkout, against
+[`apte_s2h/apte_s2h_works.txt`](https://github.com/sanskrit-lexicon/AP90/blob/master/apte_s2h/apte_s2h_works.txt)
+(05-07-2026):
+
+```sh
+cd apte_s2h
+python transcode.py slp1 deva apte_s2h_works.txt apte_s2h_works_deva_test.txt
+```
+
+Output:
+
+```
+202 Works read from apte_s2h_works.txt
+202 records written to apte_s2h_works_deva_test.txt
+```
+
+First lines of the result:
+
+```
+अ॰ पु॰ : अग्नि पुराण
+अ॰ श॰ : अन्यापदेश शतक
+अ॰ सं : अगस्त्य संहिता
+अथर्व॰ : अथर्व वेद
+```
+
+This was diffed programmatically against the already-committed
+[`apte_s2h/apte_s2h_works_deva.txt`](https://github.com/sanskrit-lexicon/AP90/blob/master/apte_s2h/apte_s2h_works_deva.txt)
+and found **byte-identical** (4,302 characters both sides) — confirming the
+script and its committed output are in sync, not stale.
+
+The same script also produces IAST:
+
+```sh
+python transcode.py slp1 roman apte_s2h_works.txt apte_s2h_works_iast.txt
+```
+
+Per [`apte_s2h/readme.md`](https://github.com/sanskrit-lexicon/AP90/blob/master/apte_s2h/readme.md):
+the period becomes the Devanagari abbreviation sign (lāghava-cihna, `॰`)
+rather than daṇḍa when transcoding to `deva`; `<X>` marks English text `X`
+left untranscoded; and IAST output capitalizes abbreviation/name-field
+words.
+
+---
+
+## Markup pipeline (`markup/abls/`)
+
+Sequential steps driven by `redo.sh`, per [`CLAUDE.md`](https://github.com/sanskrit-lexicon/AP90/blob/master/CLAUDE.md):
+
+1. `change0a.py` — regex replacements for known abbreviation patterns
+2. `updateByLine.py` — apply manual `change0b.txt` edits
+3. `abbrauth.py abbr_1.txt auth_1.txt` — merge abbreviations and authors into `abbrauth_1.txt`
+4. `prep1.py` — mark general abbreviations (`{%..%}` → `<ab>...</ab>`)
+5. `prep2.py` — mark literary sources (`Rv. 1. 22. 16` → `<ls>Rv. 1. 22. 16</ls>`)
+6. `prep3.py` — complete cross-line `<ls>` markup
+7. `hyphen_eng1.py` + `updateByLine.py` — fix English hyphenation at line boundaries
+8. `hyphen_deva1.py` + `updateByLine.py` — fix Devanagari hyphenation at line boundaries
+
+## Verb pipeline (`verbs01/`)
+
+Sequential steps driven by `redo.sh`:
+
+```sh
+python mwverb.py mw ../../mw/mw.txt mwverbs.txt
+python mwverbs1.py mwverbs.txt mwverbs1.txt
+python ap90_verb_filter.py ../ap90.txt ap90_verb_exclude.txt ap90_verb_include.txt ap90_verb_filter.txt
+python ap90_verb_filter_map.py ap90_verb_filter.txt mwverbs1.txt ap90_verb_filter_map.txt
+python verb1.py slp1 ../ap90.txt ap90_verb_filter_map.txt ap90_verb1.txt
+```
+
+This needs `ap90.txt` (from the sibling `csl-orig` checkout) and `mw.txt`
+(from the sibling `mw` repo) — both outside this repo's own tree, so it is
+documented here as the real pipeline definition rather than independently
+re-executed. Output: 3,632 verb entries identified — 1,740 prefixed, 1,822
+non-prefixed, 70 unmatched.
+
+## The general `updateByLine.py` correction pattern
+
+Used across `markup/*/` for applying change files, same as every other
+Cologne dictionary repo:
+
+```sh
+python updateByLine.py <input_file> <changein_file> <output_file>
+```
+
+Change file format: paired `NNN old <original>` / `NNN new <replacement>`
+lines; `;` prefix for comments.
+
+---
 
 ## Timeline
 
@@ -29,6 +150,8 @@ Research and correction work on **Apte's Sanskrit-English Dictionary of 1890**, 
 | 2022 | Andhra Bharati abbreviation cross-reference (`andhrabharati/`) |
 | 2022–2025 | Text corrections, encoding fixes, ongoing markup issues |
 
+---
+
 ## Projects & Milestones
 
 | Milestone | Project | Total | Open | Closed |
@@ -38,29 +161,6 @@ Research and correction work on **Apte's Sanskrit-English Dictionary of 1890**, 
 | Structured Data (3) | Project 3 | 11 | 7 | 4 |
 | Major Enhancements (4) | Project 4 | 5 | 4 | 1 |
 | **Total** | | **27** | **15** | **12** |
-
-```mermaid
-pie title Issues by milestone — closed vs open
-    "DTB closed" : 0
-    "DTB open" : 1
-    "DQ closed" : 7
-    "DQ open" : 3
-    "SD closed" : 4
-    "SD open" : 7
-    "ME closed" : 1
-    "ME open" : 4
-```
-
-```mermaid
-pie title Issue type distribution (27 total)
-    "markup" : 9
-    "content-enhancement" : 5
-    "text-correction" : 5
-    "encoding" : 4
-    "question" : 2
-    "link-target" : 1
-    "bug" : 1
-```
 
 ## Issue Typology
 
@@ -101,12 +201,20 @@ pie title Issue type distribution (27 total)
 | #27 | question | minor | Editorial question |
 | #28 | question | minor | Editorial question |
 
+---
+
 ## Labels
 
 **Type** (one per issue): `link-target` · `link-splitting` · `markup` · `text-correction` · `content-enhancement` · `encoding` · `scan-quality` · `bug` · `question`
 
 **Severity** (one per issue): `minor` · `medium` · `hard`
 
+---
+
 ## Contributors
 
 [sanskrit-lexicon](https://github.com/sanskrit-lexicon) project.
+
+---
+
+_Dr. Mārcis Gasūns_


### PR DESCRIPTION
Adds problem-first framing and a verified/illustrative usage example per the org README-quality pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)