### PR TITLE
docs: metadoc template v2 backfill (H663)

### DIFF
--- a/.ai_state.md
+++ b/.ai_state.md
@@ -1,19 +1,17 @@
-# Project Objective: [Global Goal]
-
-<!-- Replace the bracket above with the current high-level goal for this session. -->
+# Project Objective: AP90 Cologne markup/text-correction triage
 
 ## ➡️ Next Steps (Queue)
 
-- [ ] (none queued yet)
+- [ ] Revisit AP90 markup issue #14 only with a narrower sub-pattern or maintainer-approved batch scope; current broad `{#(...)#}` sampling returns thousands of mixed cases.
 
 ## 🚧 Current Work-In-Progress (WIP)
 
-- [ ] (no active task)
+- [ ] No active AP90 source edit.
 
 ## 🧠 Dev Notes & Hypotheses
 
-<!-- Persistent bugs, architectural pivots, things future-you needs to know. Keep dated. -->
+- 2026-06-27: Candidate matrix for AP90 #14 (`markup`/`minor`): source `../csl-orig/v02/ap90/ap90.txt` exists and contains many punctuation-parenthesis-in-Sanskrit-markup examples, but the broad scan (`{#(...)#}` and variants) returned 2,000+ mixed hits including compounds, gender markers, examples, and parenthesized variants. Decision: `blocked` for conservative automation; do not apply a global transform without a narrowed pattern and negative-example set.
 
 ## ✅ Completed (Recent only)
 
-<!-- Move items here as they're checked off. Trim aggressively — only the recent few. -->
+- 2026-06-27: Sampled AP90 #14 as a possible `cologne-markup-batch` candidate and rejected it for the first conservative batch because it fails the “one issue, one dictionary, one safe pattern” gate.

--- a/.ai_state.md
+++ b/.ai_state.md
@@ -1,4 +1,4 @@
-# Project Objective: AP90 Cologne markup/text-correction triage
+# Project Objective: AP90 project
 
 ## ➡️ Next Steps (Queue)
 
@@ -14,4 +14,6 @@
 
 ## ✅ Completed (Recent only)
 
+- 06-07-2026: /cologne-pages-landing — SEO landing + .nojekyll live
 - 2026-06-27: Sampled AP90 #14 as a possible `cologne-markup-batch` candidate and rejected it for the first conservative batch because it fails the “one issue, one dictionary, one safe pattern” gate.
+

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # AP90 — Apte's Sanskrit-English Dictionary (1890)
 
-_Created: 14-03-2020 · Last updated: 05-07-2026_
+_Created: 14-03-2020 · Last updated: 10-07-2026_
 
 Research and correction work on **Apte's Sanskrit-English Dictionary of
-1890** — 27 issue-tracked correction campaigns, a verb-identification
+1890** — 31 issue-tracked correction campaigns, a verb-identification
 pipeline that mapped 3,632 AP90 verb entries to Monier-Williams, and a full
 literary-source-abbreviation transcoding pipeline — part of the
 [sanskrit-lexicon](https://github.com/sanskrit-lexicon) project.
@@ -135,7 +135,9 @@ python updateByLine.py <input_file> <changein_file> <output_file>
 ```
 
 Change file format: paired `NNN old <original>` / `NNN new <replacement>`
-lines; `;` prefix for comments.
+lines; `;` prefix for comments. Corrections are never applied to the source
+directly; the org-wide snapshot → validate → batched-PR process is documented
+canonically in [csl-corrections/docs/correction-workflow.md](https://github.com/sanskrit-lexicon/csl-corrections/blob/main/docs/correction-workflow.md).
 
 ---
 
@@ -156,50 +158,56 @@ lines; `;` prefix for comments.
 
 | Milestone | Project | Total | Open | Closed |
 |---|---|---|---|---|
-| Dictionary to Book (1) | Project 1 | 1 | 1 | 0 |
+| Dictionary to Book (1) | Project 1 | 3 | 2 | 1 |
 | Digitization Quality (2) | Project 2 | 10 | 3 | 7 |
-| Structured Data (3) | Project 3 | 11 | 7 | 4 |
-| Major Enhancements (4) | Project 4 | 5 | 4 | 1 |
-| **Total** | | **27** | **15** | **12** |
+| Structured Data (3) | Project 3 | 12 | 6 | 6 |
+| Major Enhancements (4) | Project 4 | 6 | 5 | 1 |
+| **Total** | | **31** | **16** | **15** |
+
+_Milestone/open/closed counts verified live against the [AP90 issue tracker](https://github.com/sanskrit-lexicon/AP90/issues) on 10-07-2026._
 
 ## Issue Typology
 
-### Solved (12 closed)
+### Solved (15 closed)
 
 | # | Type | Severity | Summary |
 |---|---|---|---|
-| #4 | markup | medium | `<ls>` markup batch corrections |
-| #5 | content-enhancement | minor | Display upgrade |
-| #7 | encoding | minor | Character rendering fix |
-| #8 | encoding | minor | Character rendering fix |
-| #9 | markup | minor | XML tag normalisation |
-| #13 | encoding | minor | SLP1 transcoding fix |
-| #18 | text-correction | minor | German/English definition correction |
-| #19 | markup | minor | XML tag normalisation |
-| #20 | text-correction | minor | Definition correction |
-| #22 | encoding | minor | Character rendering fix |
-| #24 | markup | medium | `<ls>` markup batch corrections |
-| #25 | text-correction | minor | Definition correction |
+| [#4](https://github.com/sanskrit-lexicon/AP90/issues/4) | markup | medium | Abbreviation markup |
+| [#5](https://github.com/sanskrit-lexicon/AP90/issues/5) | content-enhancement | minor | Expansion of composite headwords |
+| [#7](https://github.com/sanskrit-lexicon/AP90/issues/7) | encoding | minor | Hyphenated non-Devanagari |
+| [#8](https://github.com/sanskrit-lexicon/AP90/issues/8) | encoding | minor | Hyphenated Devanagari at line end |
+| [#9](https://github.com/sanskrit-lexicon/AP90/issues/9) | markup | minor | Abbrev markup: compar. and superl. |
+| [#13](https://github.com/sanskrit-lexicon/AP90/issues/13) | encoding | minor | Missing characters |
+| [#18](https://github.com/sanskrit-lexicon/AP90/issues/18) | text-correction | minor | ap90ab — missing hyphens in derivations |
+| [#19](https://github.com/sanskrit-lexicon/AP90/issues/19) | markup | minor | ap90ab_v2: `{}` around Devanagari |
+| [#20](https://github.com/sanskrit-lexicon/AP90/issues/20) | text-correction | minor | nyāya maxims, appendix writers/places |
+| [#22](https://github.com/sanskrit-lexicon/AP90/issues/22) | encoding | minor | Devanagari font ligature problem (zWy) |
+| [#24](https://github.com/sanskrit-lexicon/AP90/issues/24) | markup | medium | Additional literary sources from ap90ab_v2 |
+| [#25](https://github.com/sanskrit-lexicon/AP90/issues/25) | text-correction | minor | Errata in Appendix I (Sanskrit prosody) |
+| [#27](https://github.com/sanskrit-lexicon/AP90/issues/27) | question | minor | bālhakāḥ citation variations |
+| [#29](https://github.com/sanskrit-lexicon/AP90/issues/29) | link-target | medium | Activate ap90 link targets |
+| [#30](https://github.com/sanskrit-lexicon/AP90/issues/30) | markup | minor | Minor ap90.txt markup oddities |
 
-### Open (15 open)
+### Open (16 open)
 
 | # | Type | Severity | Summary |
 |---|---|---|---|
-| #1 | content-enhancement | medium | Verb markup integration |
-| #2 | content-enhancement | medium | Bibliography enhancements |
-| #3 | content-enhancement | minor | Display upgrade |
-| #6 | bug | minor | Broken link or XML error |
-| #11 | markup | medium | `<ls>` markup corrections |
-| #12 | link-target | medium | `<ls>` click-through to PDF pages |
-| #14 | markup | minor | XML tag normalisation |
-| #15 | markup | minor | XML tag normalisation |
-| #16 | markup | minor | XML tag normalisation |
-| #17 | content-enhancement | medium | Major display upgrade |
-| #21 | text-correction | minor | Definition correction |
-| #23 | markup | medium | `<ls>` markup batch corrections |
-| #26 | text-correction | medium | Batch definition corrections |
-| #27 | question | minor | Editorial question |
-| #28 | question | minor | Editorial question |
+| [#1](https://github.com/sanskrit-lexicon/AP90/issues/1) | content-enhancement | medium | verbs01 verb markup integration |
+| [#2](https://github.com/sanskrit-lexicon/AP90/issues/2) | content-enhancement | medium | Verbs from the 1957 Apte |
+| [#3](https://github.com/sanskrit-lexicon/AP90/issues/3) | content-enhancement | minor | Add AP review |
+| [#6](https://github.com/sanskrit-lexicon/AP90/issues/6) | bug | minor | Newline for some entries |
+| [#10](https://github.com/sanskrit-lexicon/AP90/issues/10) | link-target | medium | Deep page hyperlinks (Page0463-c) |
+| [#11](https://github.com/sanskrit-lexicon/AP90/issues/11) | markup | medium | Markup of literary source references, continued |
+| [#12](https://github.com/sanskrit-lexicon/AP90/issues/12) | link-target | medium | Hitopadeśa link target |
+| [#14](https://github.com/sanskrit-lexicon/AP90/issues/14) | markup | minor | Devanagari markup changes |
+| [#15](https://github.com/sanskrit-lexicon/AP90/issues/15) | markup | minor | Misc. markup corrections |
+| [#16](https://github.com/sanskrit-lexicon/AP90/issues/16) | markup | minor | Misc markup changes, Part 2 |
+| [#17](https://github.com/sanskrit-lexicon/AP90/issues/17) | content-enhancement | medium | Andhrabharati coding of AP90 |
+| [#21](https://github.com/sanskrit-lexicon/AP90/issues/21) | question | minor | Sanskrit spelling errors |
+| [#23](https://github.com/sanskrit-lexicon/AP90/issues/23) | markup | medium | ap57_90 literary source |
+| [#26](https://github.com/sanskrit-lexicon/AP90/issues/26) | text-correction | hard | Scott's corrections to ap90 |
+| [#28](https://github.com/sanskrit-lexicon/AP90/issues/28) | question | minor | dvāja print change? |
+| [#31](https://github.com/sanskrit-lexicon/AP90/issues/31) | content-enhancement | medium | docs-pass: AP90 documentation review |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ lists, and per-issue working files for the 27 tracked corrections.
 
 | Directory | Description |
 |---|---|
+| [`docs/PIPELINE_MANUAL.md`](https://github.com/sanskrit-lexicon/AP90/blob/master/docs/PIPELINE_MANUAL.md) | **Operator manual** — every pipeline end-to-end from the real `redo.sh` files (cheat-sheet, walkthroughs, symptom→cure, maintainer appendix); metadoc at [`docs/PIPELINE_MANUAL.meta.md`](https://github.com/sanskrit-lexicon/AP90/blob/master/docs/PIPELINE_MANUAL.meta.md) |
 | [`verbs01/`](https://github.com/sanskrit-lexicon/AP90/tree/master/verbs01) | Verb identification and correlation with MW dictionary |
 | [`ap57_verbs01/`](https://github.com/sanskrit-lexicon/AP90/tree/master/ap57_verbs01) | Same pipeline for the smaller Apte AP57 |
 | [`markup/abls/`](https://github.com/sanskrit-lexicon/AP90/tree/master/markup/abls) | Literary source (`<ls>`) abbreviation markup — round 1 |

--- a/README.md
+++ b/README.md
@@ -1,22 +1,143 @@
-# AP90
+# AP90 — Apte's Sanskrit-English Dictionary (1890)
 
-Research and correction work on **Apte's Sanskrit-English Dictionary of 1890**, part of the [sanskrit-lexicon](https://github.com/sanskrit-lexicon) project.
+_Created: 14-03-2020 · Last updated: 05-07-2026_
+
+Research and correction work on **Apte's Sanskrit-English Dictionary of
+1890** — 27 issue-tracked correction campaigns, a verb-identification
+pipeline that mapped 3,632 AP90 verb entries to Monier-Williams, and a full
+literary-source-abbreviation transcoding pipeline — part of the
+[sanskrit-lexicon](https://github.com/sanskrit-lexicon) project.
+
+---
+
+## Why this repo exists
+
+The canonical source text ([`ap90.txt`](https://github.com/sanskrit-lexicon/csl-orig/blob/master/v02/ap90/ap90.txt))
+lives in the sibling `csl-orig` repo and is never edited directly. This repo
+is where the actual correction and enrichment engineering happens: markup
+normalization pipelines (five sequential `prep*.py` steps for `<ls>`
+citation markup alone), a dedicated verb-identification pipeline
+cross-referencing MW, transliteration tooling for Apte's abbreviation
+lists, and per-issue working files for the 27 tracked corrections.
+
+---
 
 ## Contents
 
 | Directory | Description |
 |---|---|
-| `verbs01/` | Verb identification and correlation with MW dictionary |
-| `ap57_verbs01/` | Same pipeline for the smaller Apte AP57 |
-| `markup/abls/` | Literary source (`<ls>`) abbreviation markup — round 1 |
-| `markup/abls1/` | Further `<ls>` markup corrections — round 2 |
-| `markup/hyphen_deva/` | Devanagari hyphenation fixes |
-| `markup/hyphen_eng/` | English hyphenation fixes |
-| `markup/ap57_90_ls/` | AP57 vs AP90 literary source comparison |
-| `apte_s2h/` | Apte abbreviation transcoding (SLP1 → IAST/Devanagari) |
-| `andhrabharati/` | Andhra Bharati cross-reference for abbreviations |
-| `compounds/AB_AP57/` | AP57 compound entry parsing |
-| `issues/` | Per-issue correction workflows |
+| [`verbs01/`](https://github.com/sanskrit-lexicon/AP90/tree/master/verbs01) | Verb identification and correlation with MW dictionary |
+| [`ap57_verbs01/`](https://github.com/sanskrit-lexicon/AP90/tree/master/ap57_verbs01) | Same pipeline for the smaller Apte AP57 |
+| [`markup/abls/`](https://github.com/sanskrit-lexicon/AP90/tree/master/markup/abls) | Literary source (`<ls>`) abbreviation markup — round 1 |
+| [`markup/abls1/`](https://github.com/sanskrit-lexicon/AP90/tree/master/markup/abls1) | Further `<ls>` markup corrections — round 2 |
+| [`markup/hyphen_deva/`](https://github.com/sanskrit-lexicon/AP90/tree/master/markup/hyphen_deva) | Devanagari hyphenation fixes |
+| [`markup/hyphen_eng/`](https://github.com/sanskrit-lexicon/AP90/tree/master/markup/hyphen_eng) | English hyphenation fixes |
+| [`markup/ap57_90_ls/`](https://github.com/sanskrit-lexicon/AP90/tree/master/markup/ap57_90_ls) | AP57 vs AP90 literary source comparison |
+| [`apte_s2h/`](https://github.com/sanskrit-lexicon/AP90/tree/master/apte_s2h) | Apte abbreviation transcoding (SLP1 → IAST/Devanagari) — see [Usage](#usage-transcoding-apte-abbreviations-verified-runnable) below |
+| [`andhrabharati/`](https://github.com/sanskrit-lexicon/AP90/tree/master/andhrabharati) | Andhra Bharati cross-reference for abbreviations |
+| [`compounds/AB_AP57/`](https://github.com/sanskrit-lexicon/AP90/tree/master/compounds/AB_AP57) | AP57 compound entry parsing |
+| [`issues/`](https://github.com/sanskrit-lexicon/AP90/tree/master/issues) | Per-issue correction workflows |
+
+---
+
+## Usage: transcoding Apte abbreviations (verified runnable)
+
+[`apte_s2h/`](https://github.com/sanskrit-lexicon/AP90/tree/master/apte_s2h)
+holds a transliteration of the Apte Student edition's Sanskrit-to-Hindi
+abbreviation list (202 works, e.g. `a. pu. : agni purARa`), and
+[`apte_s2h/transcode.py`](https://github.com/sanskrit-lexicon/AP90/blob/master/apte_s2h/transcode.py)
+converts it between transliteration schemes using the shared XML-driven
+`transcoder` module bundled in [`apte_s2h/transcoder/`](https://github.com/sanskrit-lexicon/AP90/tree/master/apte_s2h/transcoder).
+
+This is fully self-contained — all inputs live in the repo — and was
+executed directly, in this checkout, against
+[`apte_s2h/apte_s2h_works.txt`](https://github.com/sanskrit-lexicon/AP90/blob/master/apte_s2h/apte_s2h_works.txt)
+(05-07-2026):
+
+```sh
+cd apte_s2h
+python transcode.py slp1 deva apte_s2h_works.txt apte_s2h_works_deva_test.txt
+```
+
+Output:
+
+```
+202 Works read from apte_s2h_works.txt
+202 records written to apte_s2h_works_deva_test.txt
+```
+
+First lines of the result:
+
+```
+अ॰ पु॰ : अग्नि पुराण
+अ॰ श॰ : अन्यापदेश शतक
+अ॰ सं : अगस्त्य संहिता
+अथर्व॰ : अथर्व वेद
+```
+
+This was diffed programmatically against the already-committed
+[`apte_s2h/apte_s2h_works_deva.txt`](https://github.com/sanskrit-lexicon/AP90/blob/master/apte_s2h/apte_s2h_works_deva.txt)
+and found **byte-identical** (4,302 characters both sides) — confirming the
+script and its committed output are in sync, not stale.
+
+The same script also produces IAST:
+
+```sh
+python transcode.py slp1 roman apte_s2h_works.txt apte_s2h_works_iast.txt
+```
+
+Per [`apte_s2h/readme.md`](https://github.com/sanskrit-lexicon/AP90/blob/master/apte_s2h/readme.md):
+the period becomes the Devanagari abbreviation sign (lāghava-cihna, `॰`)
+rather than daṇḍa when transcoding to `deva`; `<X>` marks English text `X`
+left untranscoded; and IAST output capitalizes abbreviation/name-field
+words.
+
+---
+
+## Markup pipeline (`markup/abls/`)
+
+Sequential steps driven by `redo.sh`, per [`CLAUDE.md`](https://github.com/sanskrit-lexicon/AP90/blob/master/CLAUDE.md):
+
+1. `change0a.py` — regex replacements for known abbreviation patterns
+2. `updateByLine.py` — apply manual `change0b.txt` edits
+3. `abbrauth.py abbr_1.txt auth_1.txt` — merge abbreviations and authors into `abbrauth_1.txt`
+4. `prep1.py` — mark general abbreviations (`{%..%}` → `<ab>...</ab>`)
+5. `prep2.py` — mark literary sources (`Rv. 1. 22. 16` → `<ls>Rv. 1. 22. 16</ls>`)
+6. `prep3.py` — complete cross-line `<ls>` markup
+7. `hyphen_eng1.py` + `updateByLine.py` — fix English hyphenation at line boundaries
+8. `hyphen_deva1.py` + `updateByLine.py` — fix Devanagari hyphenation at line boundaries
+
+## Verb pipeline (`verbs01/`)
+
+Sequential steps driven by `redo.sh`:
+
+```sh
+python mwverb.py mw ../../mw/mw.txt mwverbs.txt
+python mwverbs1.py mwverbs.txt mwverbs1.txt
+python ap90_verb_filter.py ../ap90.txt ap90_verb_exclude.txt ap90_verb_include.txt ap90_verb_filter.txt
+python ap90_verb_filter_map.py ap90_verb_filter.txt mwverbs1.txt ap90_verb_filter_map.txt
+python verb1.py slp1 ../ap90.txt ap90_verb_filter_map.txt ap90_verb1.txt
+```
+
+This needs `ap90.txt` (from the sibling `csl-orig` checkout) and `mw.txt`
+(from the sibling `mw` repo) — both outside this repo's own tree, so it is
+documented here as the real pipeline definition rather than independently
+re-executed. Output: 3,632 verb entries identified — 1,740 prefixed, 1,822
+non-prefixed, 70 unmatched.
+
+## The general `updateByLine.py` correction pattern
+
+Used across `markup/*/` for applying change files, same as every other
+Cologne dictionary repo:
+
+```sh
+python updateByLine.py <input_file> <changein_file> <output_file>
+```
+
+Change file format: paired `NNN old <original>` / `NNN new <replacement>`
+lines; `;` prefix for comments.
+
+---
 
 ## Timeline
 
@@ -29,6 +150,8 @@ Research and correction work on **Apte's Sanskrit-English Dictionary of 1890**, 
 | 2022 | Andhra Bharati abbreviation cross-reference (`andhrabharati/`) |
 | 2022–2025 | Text corrections, encoding fixes, ongoing markup issues |
 
+---
+
 ## Projects & Milestones
 
 | Milestone | Project | Total | Open | Closed |
@@ -38,29 +161,6 @@ Research and correction work on **Apte's Sanskrit-English Dictionary of 1890**, 
 | Structured Data (3) | Project 3 | 11 | 7 | 4 |
 | Major Enhancements (4) | Project 4 | 5 | 4 | 1 |
 | **Total** | | **27** | **15** | **12** |
-
-```mermaid
-pie title Issues by milestone — closed vs open
-    "DTB closed" : 0
-    "DTB open" : 1
-    "DQ closed" : 7
-    "DQ open" : 3
-    "SD closed" : 4
-    "SD open" : 7
-    "ME closed" : 1
-    "ME open" : 4
-```
-
-```mermaid
-pie title Issue type distribution (27 total)
-    "markup" : 9
-    "content-enhancement" : 5
-    "text-correction" : 5
-    "encoding" : 4
-    "question" : 2
-    "link-target" : 1
-    "bug" : 1
-```
 
 ## Issue Typology
 
@@ -101,12 +201,20 @@ pie title Issue type distribution (27 total)
 | #27 | question | minor | Editorial question |
 | #28 | question | minor | Editorial question |
 
+---
+
 ## Labels
 
 **Type** (one per issue): `link-target` · `link-splitting` · `markup` · `text-correction` · `content-enhancement` · `encoding` · `scan-quality` · `bug` · `question`
 
 **Severity** (one per issue): `minor` · `medium` · `hard`
 
+---
+
 ## Contributors
 
 [sanskrit-lexicon](https://github.com/sanskrit-lexicon) project.
+
+---
+
+_Dr. Mārcis Gasūns_

--- a/changelog.md
+++ b/changelog.md
@@ -1,0 +1,20 @@
+# Changelog
+
+All notable changes to AP90 are documented here.
+
+This repository does not currently publish versioned release notes. Entries use
+dated maintenance snapshots; keep upcoming work under [Unreleased] until it is
+ready for a dated entry.
+
+## [1.0.0] - 2026-06-13
+
+### Added
+- Added this changelog so repository-level changes have a stable home.
+- Recorded the current repository purpose: Research and correction work on Apte's Sanskrit-English Dictionary of 1890, part of the sanskrit-lexicon project.
+
+### Recent Git History
+- 2026-05-29 ai-wip: add .pre-commit-config.yaml (yaml-only)
+- 2026-05-29 ai-wip: add CodeQL SAST workflow (php)
+- 2026-05-29 ai-wip: add .github/dependabot.yml for GitHub Actions auto-updates
+- 2026-05-29 fix(ci): smarter change-file validator + per-repo excludes
+- 2026-05-29 fix(ci): smarter change-file validator + per-repo excludes

--- a/docs/PIPELINE_MANUAL.md
+++ b/docs/PIPELINE_MANUAL.md
@@ -1,0 +1,325 @@
+# AP90 pipelines — operator manual
+
+_Created: 11-07-2026 · Last updated: 11-07-2026_
+
+This is the **operator manual** for the AP90 repository: how the markup,
+hyphenation, verb-identification, transcoding and issue-campaign pipelines for
+Apte's 1890 *Sanskrit-English Dictionary* actually run — from the real
+`redo.sh` files, not from their idealized readme summaries (two material
+discrepancies between the two are corrected below).
+
+Three documents describe this repo, with different jobs:
+
+- **What the repo is** (history, issue typology, the verified apte_s2h usage
+  example) — [README.md](https://github.com/sanskrit-lexicon/AP90/blob/master/README.md);
+- **Code contract for AI/code sessions** —
+  [CLAUDE.md](https://github.com/sanskrit-lexicon/AP90/blob/master/CLAUDE.md)
+  (note: its abls and verbs01 step lists are idealized — see
+  [the corrections](#two-corrections-to-the-existing-docs));
+- **How to operate the pipelines** (this document) —
+  [docs/PIPELINE_MANUAL.md](https://github.com/sanskrit-lexicon/AP90/blob/master/docs/PIPELINE_MANUAL.md).
+
+Commands are quoted verbatim from the actual `redo*.sh` drivers and per-folder
+readmes; scripts and paths verified on disk 11-07-2026. The apte_s2h pipeline
+was previously live-verified byte-identical (05-07-2026, recorded in the
+README); the others are transcription-verified — most are one-time campaigns
+pinned to csl-orig commits.
+
+## Cheat-sheet: the shared correction idiom
+
+Everything here is the standard Cologne loop over the sibling
+[csl-orig](https://github.com/sanskrit-lexicon/csl-orig)'s
+`v02/ap90/ap90.txt` (never edited in place):
+
+```sh
+# 0. Snapshot, pinned by commit (record the hash in your readme)
+git -C <csl-orig> show <hash>:v02/ap90/ap90.txt > ap90_0.txt
+
+# 1. Generate a change file, then apply it — generator and applier are SEPARATE steps
+python <generator>.py ap90_0.txt change_1.txt        # emits transactions
+python updateByLine.py ap90_0.txt change_1.txt ap90_1.txt
+
+# 2. Validate via csl-pywork, then deliver per the batched-PR rule
+cp ap90_N.txt <csl-orig>/v02/ap90/ap90.txt
+cd <csl-pywork>/v02 && sh generate_dict.sh ap90 ../../ap90 && sh xmlchk_xampp.sh ap90
+```
+
+Change-file format: paired `NNN old <text>` / `NNN new <text>` lines, `;`
+comments — identical to every Cologne repo. Delivery: never push csl-orig
+directly; queue and ship as one consolidated batch PR per the canonical
+[correction workflow](https://github.com/sanskrit-lexicon/csl-corrections/blob/main/docs/correction-workflow.md).
+
+**Ordering is commit-hash chaining.** The historical campaigns ran in a strict
+sequence, each starting from the commit the previous one installed:
+hyphen_deva (→ `29e18e69`) → abls Round 1 (`29e18e69` → `19c7ee9c`) → abls1
+Round 2 (`19c7ee9c` → `37f98f8b`). Reproduce a campaign only against **its
+own** pinned start commit.
+
+## Two corrections to the existing docs
+
+Verified against the scripts on 11-07-2026 — trust these over CLAUDE.md/README
+prose:
+
+1. **`markup/abls/redo.sh` is 12 invocations, not 8 steps.** `change0a.py`
+   *generates* `change0a.txt` (256 transactions); it does not apply anything —
+   a separate `updateByLine.py` call applies it, followed by a second
+   `updateByLine.py` for the manual `change0b.txt`. CLAUDE.md collapses the
+   generator and applier into one step. (Cosmetic defect: the script's final
+   `echo` names `ap90_4.txt` while the last command writes `ap90_5.txt`.)
+2. **`verbs01/redo.sh` runs 4 commands, not the documented 5** — the two MW
+   verb-extraction commands are commented out, and `mwverb.py` /
+   `mwverbs1.py` / `mwverbs*.txt` **do not exist in `verbs01/`** (they live
+   only in `ap57_verbs01/`). `mwverbs1.txt` is consumed from the sibling
+   [MWS](https://github.com/sanskrit-lexicon/MWS) repo
+   (`../../MWS/mwverbs/mwverbs1.txt`). The redo also produces a sixth,
+   undocumented output: `ap90_verb1_deva.txt` (Devanagari edition).
+
+## Map of the workspaces
+
+| Workspace | What it did | Issues | Status |
+|---|---|---|---|
+| [markup/hyphen_deva/](https://github.com/sanskrit-lexicon/AP90/tree/master/markup/hyphen_deva) | resolve 13,601 Devanagari end-of-line hyphens (3 staged passes + reversibility proofs) | [#8](https://github.com/sanskrit-lexicon/AP90/issues/8) | done; ran **first** in the chain |
+| [markup/hyphen_eng/](https://github.com/sanskrit-lexicon/AP90/tree/master/markup/hyphen_eng) | resolve 26,749 English end-of-line hyphens (26,652 applied, 97 open questions) | [#7](https://github.com/sanskrit-lexicon/AP90/issues/7) | done |
+| [markup/abls/](https://github.com/sanskrit-lexicon/AP90/tree/master/markup/abls) | Round 1 `<ab>`/`<ls>` abbreviation + literary-source markup | [#4](https://github.com/sanskrit-lexicon/AP90/issues/4)/[#9](https://github.com/sanskrit-lexicon/AP90/issues/9)/[#11](https://github.com/sanskrit-lexicon/AP90/issues/11)/[#24](https://github.com/sanskrit-lexicon/AP90/issues/24) | done |
+| [markup/abls1/](https://github.com/sanskrit-lexicon/AP90/tree/master/markup/abls1) | Round 2 `<ls>` corrections (change6→change15) | [#11](https://github.com/sanskrit-lexicon/AP90/issues/11)/[#24](https://github.com/sanskrit-lexicon/AP90/issues/24)/[#30](https://github.com/sanskrit-lexicon/AP90/issues/30) | done; `filtercode/` is a non-runnable "sampling" |
+| [markup/ap57_90_ls/](https://github.com/sanskrit-lexicon/AP90/tree/master/markup/ap57_90_ls) | AP57↔AP90 `<ls>` tooltip variant merge (data-only, no scripts) | [#23](https://github.com/sanskrit-lexicon/AP90/issues/23) | done; changes deliberately NOT in csl-corrections' printchange ledger |
+| [verbs01/](https://github.com/sanskrit-lexicon/AP90/tree/master/verbs01) | 3,632 AP90 verb entries identified + mapped to MW | [#1](https://github.com/sanskrit-lexicon/AP90/issues/1)/[#2](https://github.com/sanskrit-lexicon/AP90/issues/2) | **re-runnable** (needs MWS sibling) |
+| [ap57_verbs01/](https://github.com/sanskrit-lexicon/AP90/tree/master/ap57_verbs01) | same pipeline for AP57 (3,978 verbs) + AP57↔AP90 verb diff | [#2](https://github.com/sanskrit-lexicon/AP90/issues/2)/[#23](https://github.com/sanskrit-lexicon/AP90/issues/23) | **re-runnable, fully self-contained** |
+| [apte_s2h/](https://github.com/sanskrit-lexicon/AP90/tree/master/apte_s2h) | 202-work Apte-Student abbreviation list, SLP1 → Devanagari/IAST | — | **re-runnable; live-verified byte-identical 05-07-2026** |
+| [andhrabharati/](https://github.com/sanskrit-lexicon/AP90/tree/master/andhrabharati) | AndhraBharati re-digitization + abbreviation lists (data-only) | [#17](https://github.com/sanskrit-lexicon/AP90/issues/17) | ingested; `ap90ab_v2_suggest.txt` TODO list still unapplied |
+| [compounds/AB_AP57/](https://github.com/sanskrit-lexicon/AP90/tree/master/compounds/AB_AP57) | parse 37,649 compounds out of AB's AP57 (36,589 entries) | [#5](https://github.com/sanskrit-lexicon/AP90/issues/5) | done |
+| [issues/issue26/](https://github.com/sanskrit-lexicon/AP90/tree/master/issues/issue26) | Scott/Usha/Jim correction batch + alternate-headword promotion (+2,662 entries) | [#26](https://github.com/sanskrit-lexicon/AP90/issues/26) | **open**, multi-part |
+| [issues/issue29/](https://github.com/sanskrit-lexicon/AP90/tree/master/issues/issue29) | activate `<ls>` link targets for AP90 (13 activated) | [#29](https://github.com/sanskrit-lexicon/AP90/issues/29) | **open**; cologne install + csl-lslink step = TODO |
+
+The committed [issues/readme.txt](https://github.com/sanskrit-lexicon/AP90/blob/master/issues/readme.txt)
+lists only these two folders — most campaign work in this repo predates the
+`issues/` convention and lives in the topic directories above.
+
+## Environment and prerequisites
+
+- **Python 3**, stdlib only. `updateByLine.py` (164 lines) and
+  `transcoder.py` (+ per-dir XML tables) are copy-vendored per workspace —
+  frozen records, no shared module.
+- **Git Bash / POSIX shell** for the `redo*.sh` drivers.
+- **Sibling checkouts:** csl-orig (`v02/ap90/`, `v02/ap57/`, `v02/ap/`,
+  `v02/mw/`), csl-pywork (`generate_dict.sh` + `xmlchk_xampp.sh` + the
+  `distinctfiles/*/tooltip.txt` inputs), MWS (`mwverbs/mwverbs1.txt` for
+  verbs01), csl-corrections (correction-form intake + printchange ledgers),
+  csl-websanlexicon + csl-apidev (`basicadjust.php`, issue29), csl-lslink
+  (link sqlite build), `AP90Scan`/`AP57Scan` (scan images).
+- **Three path conventions coexist** — remap per workspace: `markup/*` uses
+  bare `../ap90.txt` relatives; `verbs01/redo.sh` uses the two-root
+  `../../../cologne/csl-orig/v02` layout; `issues/*` readmes use absolute
+  `/c/xampp/htdocs/...`. None are parameterized.
+- **Default branch is `master`** (not main) — a local stale `main` branch may
+  exist in old checkouts; blob links and PRs target `master`.
+- No secrets; no network access.
+
+## Walkthrough 1 — markup Round 1 ([markup/abls/](https://github.com/sanskrit-lexicon/AP90/tree/master/markup/abls))
+
+The real [redo.sh](https://github.com/sanskrit-lexicon/AP90/blob/master/markup/abls/redo.sh), verbatim:
+
+```sh
+python change0a.py ap90_0.txt change0a.txt              # GENERATES 256 transactions
+python updateByLine.py ap90_0.txt change0a.txt ap90_0a.txt
+python updateByLine.py ap90_0a.txt change0b.txt ap90_0b.txt   # manual edits
+python abbrauth.py abbr_1.txt auth_1.txt abbrauth_1.txt       # 269 abbrevs+authors merged
+python prep1.py ap90_0b.txt abbrauth_1.txt ap90_1.txt abbr_2.txt   # {%..%} -> <ab>
+python prep2.py ap90_1.txt abbrauth_1.txt ap90_2.txt auth_2.txt    # Rv. 1.22.16 -> <ls>
+python prep3.py ap90_2.txt auth_2.txt ap90_3.txt changes3.txt      # cross-line <ls>
+python hyphen_eng1.py ap90_3.txt hyphen_eng.txt hyphen_eng_questions.txt
+python updateByLine.py ap90_3.txt hyphen_eng.txt ap90_4.txt
+python hyphen_deva1.py ap90_4.txt hyphen_deva.txt hyphen_deva_questions.txt
+python updateByLine.py ap90_4.txt hyphen_deva.txt ap90_5.txt   # (script's echo says _4 — stale label)
+```
+
+Consumes `ap90_0.txt` (= csl-orig `29e18e69`) + the abbreviation/author lists
+harvested from the ap90 header (`abbr_1.txt`, `auth_1.txt`; A.D./B.C. added
+by hand); produces `ap90_5.txt`, installed as csl-orig `19c7ee9c`. Known
+residue recorded in its readme: 15 type-2 duplicate abbreviations (`N.`,
+`P.`, `U.`, `A.` …), bare `' A.'`/`' P'` cases, and one `Bhāv. P.` typo.
+`change_misc*.py` are manual-assist generators — **not** part of the chain.
+
+**Round 2** ([markup/abls1/](https://github.com/sanskrit-lexicon/AP90/tree/master/markup/abls1),
+`redo2.sh`) is ten chained `updateByLine.py temp_ap90_N.txt changeN.txt
+temp_ap90_N+1.txt` applications for `change6.txt`…`change15.txt` (numbering
+continues Round 1's `_0.._5`), taking csl-orig `19c7ee9c` → `37f98f8b`. The
+change files were built partly by hand and partly by the `filtercode/`
+scripts, which the readme explicitly keeps as a non-runnable "sampling".
+Stats regen: `python ls_summary1.py temp_ap90_15.txt tooltip.txt ls_summary1.txt`.
+
+## Walkthrough 2 — hyphenation ([markup/hyphen_deva/](https://github.com/sanskrit-lexicon/AP90/tree/master/markup/hyphen_deva), [markup/hyphen_eng/](https://github.com/sanskrit-lexicon/AP90/tree/master/markup/hyphen_eng))
+
+**Devanagari** (ran first of all campaigns): manual `changes0_edit.txt` (53) →
+`spacechg.py` (986 space-boundary fixes; writes `changes0b.txt` — the
+readme's `changes_0b.txt` spelling is wrong) → three staged hyphen passes
+(`hyphen1.py` 1,232 + `<lbinfo n=.../>` markers; `hyphen2.py` 12,298;
+`hyphen3.py` ~35 `{#--#}` cases), each applied via `updateByLine.py`, ending
+in `ap90_3.txt`. Every stage has a **reversibility proof**
+(`restore1/2/3.py`, `restore_hyphen2.py` — diff back to the input must be 0);
+keep that discipline in any new hyphen work.
+
+**English** (no redo.sh; the readme is the runbook):
+
+```sh
+python hyphen_eng.py ap90_0.txt hyphen_changes.txt hyphen_questions.txt  # 26,749 found / 26,652 resolved
+python updateByLine.py ap90_0.txt hyphen_changes.txt ap90_1.txt
+# reversibility proof via restore_hyphen_eng.py; then install:
+cp ap90_1.txt ../ap90.txt
+sh generate_dict.sh ap90 ../../AP90Scan/2020/
+```
+
+Open residue: 97 unresolved `-$` cases in `hyphen_questions.txt`; ~3,000
+resolutions flagged `type=false` by English spell-check — a review pool, not
+errors.
+
+## Walkthrough 3 — the verb pipelines
+
+**AP90** ([verbs01/redo.sh](https://github.com/sanskrit-lexicon/AP90/blob/master/verbs01/redo.sh),
+the real 4 commands — see [correction #2](#two-corrections-to-the-existing-docs)):
+
+```sh
+orig="../../../cologne/csl-orig/v02"
+mwverbs1="../../MWS/mwverbs/mwverbs1.txt"
+python ap90_verb_filter.py ${orig}/ap90/ap90.txt ap90_verb_exclude.txt ap90_verb_include.txt ap90_verb_filter.txt
+python ap90_verb_filter_map.py ap90_verb_filter.txt ${mwverbs1} ap90_verb_filter_map.txt
+python verb1.py slp1 ${orig}/ap90/ap90.txt ap90_verb_filter_map.txt ap90_verb1.txt
+python verb1.py deva ${orig}/ap90/ap90.txt ap90_verb_filter_map.txt ap90_verb1_deva.txt
+```
+
+Filter (pattern codes C = class-pada 3,338 · D = denominative 286 · P =
+pada-only 8, with hand-curated include/exclude overrides) → MW mapping →
+final reports. Recorded results: **3,632 verbs** (1,740 prefixed / 1,822
+non-prefixed / 70 unmatched `mw=?`; 2,987 same spelling as MW, 575 differ).
+
+**AP57** ([ap57_verbs01/redo.sh](https://github.com/sanskrit-lexicon/AP90/blob/master/ap57_verbs01/redo.sh))
+is the **self-contained** variant: it *does* run `mwverb.py` + `mwverbs1.py`
+locally (against sibling `mw.txt`), works from a local `temp_ap57.txt`
+snapshot, adds pattern codes `€` (2,979 — AP57's literal euro-sign class-pada
+sigil), `T` (' To ' English-definition verbs, 286) and `X` (include-list,
+123), and ends with the unique `compare_filter_map.py` →
+`ap57_ap90_compare.txt`: the AP57↔AP90 verb diff (**8 verbs only in AP90,
+300 only in AP57**). Recorded results: **3,978 verbs** (1,926 / 1,954 / 98
+unmatched).
+
+## Walkthrough 4 — transcoding & data ingests
+
+- **[apte_s2h/](https://github.com/sanskrit-lexicon/AP90/tree/master/apte_s2h)**
+  (re-runnable, live-verified): `python transcode.py slp1 deva
+  apte_s2h_works.txt apte_s2h_works_deva.txt` and `slp1 roman` for IAST —
+  202 works each. Traps: period renders as lāghava-cihna `॰` (not daṇḍa) in
+  Devanagari; `<X>` spans stay untranscoded English; IAST output capitalizes
+  name words. The README's Usage section documents the byte-identical
+  verification run.
+- **[andhrabharati/](https://github.com/sanskrit-lexicon/AP90/tree/master/andhrabharati)**
+  (data-only): AB's re-coded AP90 (`ap90ab.txt`, `ap90ab_v2.txt`) plus
+  normalized abbreviation lists (`{X}` = normal abbrevs, `<X>` = literary
+  sources). `ap90ab_v2_suggest.txt` is a still-open `* TODO` punch-list of
+  abbreviation normalizations.
+- **[compounds/AB_AP57/](https://github.com/sanskrit-lexicon/AP90/tree/master/compounds/AB_AP57)**:
+  `deva_slp1.py deva slp1 AP57entries.txt AP57entries_slp1.txt` →
+  `parseprep.py` (85,168 → 82,383 lines) → `parse.py` → `ap57b.txt` +
+  pointer file: 36,589 entries, 4,365 with compounds, **37,649 compounds**.
+  (Its readme says `AB57entries.txt`; the real file is `AP57entries.txt`.)
+
+## Walkthrough 5 — the two open issue campaigns
+
+**[issues/issue26/](https://github.com/sanskrit-lexicon/AP90/tree/master/issues/issue26)
+(Scott's corrections, hard, open).** Four parts so far: (1) hand-edited
+correction form → `diff_to_changes_dict.py` → `change_1.txt` (432), cases
+bucketed into `case_*.txt`; (2) `LBdash.py` — the `({#--X#})` → `{#--(X)#}`
+line-break defect, `change_2.txt` (1,790); (3) `althw_1.py` — 701
+comma-separated alternate headwords promoted to real `<L>` entries (32,176 →
+32,877); (4) `redo_4.sh`: census → `althw_2_prep.py` → `althw_2.py` → census
+diff — **1,961 more alt-headword entries** (→ 34,838), powered by the
+1,971-line hand-built dictionary `althw_2_man_1.py`, plus the `althw_2fix`
+pass (2 print-changes). Known folder defects: `readme_althw_2.txt` has a
+duplicated-argument command typo; Part 4's commit message says "althw_1";
+several print-change debates spun off as issues
+[#27](https://github.com/sanskrit-lexicon/AP90/issues/27)/[#28](https://github.com/sanskrit-lexicon/AP90/issues/28).
+
+**[issues/issue29/](https://github.com/sanskrit-lexicon/AP90/tree/master/issues/issue29)
+(link targets, open).** `lsextract_all.py` inventories `<ls>` refs for `ap`
+and `ap90` against their csl-pywork tooltips; `lsdump_all.py` dumps the 330
+tooltip contexts; `link_target_work_ap90.txt` (seeded from AP's issue19 list)
+tracks **13 activated targets**. Delivery edits `basicadjust.php` in BOTH
+csl-websanlexicon and csl-apidev; `redo_new.sh` intentionally restores the
+websanlexicon copy but leaves csl-apidev revised (it echoes a WARNING to that
+effect). **Still TODO:** the cologne install and the csl-lslink sqlite build
+(`sh redo_one_xampp.sh ap90` → 18,741 links) — and `redo_new.sh` is an
+un-repointed copy of AP's version (`cd .../AP/issues/issue29`, regenerates
+dict `ap` not `ap90`). Fix those before trusting a run.
+
+## Symptom → cause → cure
+
+| Symptom | Cause | Cure |
+|---|---|---|
+| `verbs01`: `mwverb.py: No such file` | Running the documented 5-command block — those scripts exist only in `ap57_verbs01/` | Use the real 4-command `redo.sh`; ensure the sibling MWS checkout provides `mwverbs/mwverbs1.txt` |
+| `verbs01/redo.sh`: csl-orig not found | It assumes the two-root `../../../cologne/csl-orig/v02` layout | Remap or symlink; other workspaces use different conventions (see Environment) |
+| `updateByLine.py`: old-text mismatch | Wrong base snapshot — campaigns are commit-pinned and chained | Re-extract with `git show <the folder's recorded hash>:v02/ap90/ap90.txt` |
+| A markup campaign "finds nothing" on current ap90.txt | It already landed (abls installed `19c7ee9c`, abls1 `37f98f8b`) | Expected; reproduce against the pinned start commit only |
+| `redo_new.sh` (issue29) regenerates the wrong dictionary | It's an unre-pointed copy of AP's issue19 script (`ap`, and a `cd` into the AP repo) | Edit the `cd` and dict code to `ap90` first — flagged as an open defect |
+| csl-apidev shows uncommitted `basicadjust.php` changes after issue29 work | `redo_new.sh` deliberately leaves it revised (prints a WARNING) | Intentional: that copy is the delivery; commit or discard consciously — see the fork-sync check skill |
+| Devanagari output shows daṇḍa where the print has an abbreviation dot | Wrong transcode of the period | `apte_s2h/transcode.py` maps `.` → lāghava-cihna `॰` by design; check `<X>` English spans too |
+| `€` in AP57 verb patterns looks like mojibake | It's a literal sigil AP57's digitization uses for class-pada verb forms (2,979 hits) | Leave it; it is load-bearing in `ap57_verb_filter.py` |
+| Hyphen-fix output looks wrong for some English words | ~3,000 resolutions are flagged `type=false` (fail spell-check) in `hyphen_changes.txt` | That column is the review queue; the 97 `hyphen_questions.txt` cases are still open |
+| You can't find round-2 change files 1–5 | `abls1` numbering continues Round 1's `ap90_0..5` | change6…change15 are the complete Round-2 set |
+| Reproducing `changes0b.txt` per the hyphen_deva readme fails | Readme spells it `changes_0b.txt`; the script writes `changes0b.txt` | Trust the `redo.sh` spelling |
+
+## Glossary
+
+| Term | Meaning here |
+|---|---|
+| AP90 / AP57 | Apte's *Sanskrit-English Dictionary*, 1890 edition (code `ap90`) vs the revised 1957–59 edition (code `ap`, worked in the sibling [AP](https://github.com/sanskrit-lexicon/AP) repo; `ap57` snapshots here) |
+| `<ab>` / `<ls>` | abbreviation / literary-source citation tags — the objects of the abls rounds and issue29's link targets |
+| abbrauth | the merged abbreviation+author control list (`abbrauth_1.txt`, 269 rows) driving prep1–prep3 |
+| lbinfo | `<lbinfo n=.../>` markers hyphen passes insert to preserve original line-break info |
+| reversibility proof | each hyphen stage's `restore*.py` must diff back to its input with 0 lines — the campaign's safety property |
+| pattern codes | verb-filter classes: C class-pada, D denominative, P pada-only (+ AP57's `€`, `T`, `X`) |
+| lāghava-cihna | `॰` (U+0970), the Devanagari abbreviation sign the transcoder uses for `.` |
+| AB / AndhraBharati | the independent re-digitization ingested in `andhrabharati/` |
+| link target | a clickable `<ls>` → scanned-page mapping; 13 activated for AP90 so far (issue29) |
+| commit-hash chaining | each campaign starts from the csl-orig commit the previous one installed — the repo's real ordering key |
+
+## Maintainer appendix
+
+### Invariants
+
+1. **Campaigns are commit-pinned and chained** — every folder's readme records
+   its start and install hashes; the chain order is hyphen_deva → abls →
+   abls1.
+2. **Generator ≠ applier** — change files are always produced by one script
+   and applied by `updateByLine.py`; never fold the two together.
+3. **Hyphen passes are reversible** — a `restore*.py` diff-to-zero accompanies
+   every stage; new hyphen work must keep the proof.
+4. **Entry-count checkpoints** for issue26's alt-headword promotion:
+   32,176 → 32,877 (althw_1) → 34,838 (althw_2).
+5. **apte_s2h is deterministic** — re-running reproduces the committed outputs
+   byte-identically (verified 05-07-2026).
+
+### Known traps and observed defects
+
+1. **CLAUDE.md's two idealized step lists** (abls "8 steps", verbs01 "5
+   commands") don't match the real `redo.sh` files — corrected above; fixing
+   CLAUDE.md is metadoc backlog #2.
+2. **issue29's `redo_new.sh` is un-repointed** (targets `ap`, `cd`s into the
+   AP repo) and its cologne/csl-lslink delivery is TODO.
+3. **issue26 folder defects**: duplicated argument in `readme_althw_2.txt`'s
+   command, wrong commit message on Part 4, one benign ERROR line
+   (kuraMgamaH) in althw_1's run.
+4. **`ap57_90_ls` changes are deliberately absent from csl-corrections'
+   printchange ledger** — a documented provenance gap, not an oversight.
+5. **`andhrabharati/ap90ab_v2_suggest.txt`** is an unapplied TODO punch-list
+   of abbreviation normalizations — open work, easy to miss.
+6. **Vendored engine copies** (`updateByLine.py` ×4, `transcoder.py` ×4) are
+   frozen per folder; fix forward in the newest copy.
+7. **Stray committed artifact**: `apte_s2h/__pycache__/…​.pyc`.
+8. **`redo.sh` stale echo** in abls (says `ap90_4.txt`, writes `ap90_5.txt`)
+   and the hyphen_deva readme's `changes_0b.txt` misspelling — cosmetic, but
+   they cost a newcomer real time.
+
+Improvement backlog, provenance and revision history live in the companion
+metadoc:
+[docs/PIPELINE_MANUAL.meta.md](https://github.com/sanskrit-lexicon/AP90/blob/master/docs/PIPELINE_MANUAL.meta.md).
+
+_Dr. Mārcis Gasūns_

--- a/docs/PIPELINE_MANUAL.meta.md
+++ b/docs/PIPELINE_MANUAL.meta.md
@@ -1,0 +1,84 @@
+# PIPELINE_MANUAL.md — metadoc
+
+_Created: 11-07-2026 · Last updated: 11-07-2026_
+
+Companion record for
+[docs/PIPELINE_MANUAL.md](https://github.com/sanskrit-lexicon/AP90/blob/master/docs/PIPELINE_MANUAL.md)
+— purpose, provenance, improvement backlog and revision history of the manual
+itself (not of the pipelines it documents).
+
+## Purpose
+
+Give a new operator/contributor a runnable understanding of AP90's pipeline
+family — the markup rounds (abls/abls1), the hyphenation campaigns with their
+reversibility proofs, the two verb pipelines (AP90 vs the self-contained
+AP57 variant), the transcoding/ingest workspaces, and the two open issue
+campaigns (#26 alt-headwords, #29 link targets) — **from the real `redo.sh`
+files**, correcting the two idealized step lists in CLAUDE.md/README.
+
+## Audience
+
+- **Operators** re-running the verb pipelines or apte_s2h, or picking up the
+  open issue26/issue29 work (cheat-sheet, walkthroughs 3/5, symptom table);
+- **Maintainers** touching the markup/hyphen tooling (corrections section,
+  appendix invariants + traps);
+- **Historians** of the 2020-era markup/hyphenation chain (commit-hash
+  chaining, walkthroughs 1–2).
+
+## Provenance
+
+- Authored 11-07-2026 by Fable 5 (`claude-fable-5`) executing handoff
+  [H523-Fable_AP90_markup_verbs_pipeline_manual_10.07.26.md](https://github.com/gasyoun/Uprava/blob/main/handoffs/H523-Fable_AP90_markup_verbs_pipeline_manual_10.07.26.md)
+  (manual-coverage census batch H501–H531).
+- Modelled on the gold-standard operator manual
+  [RussianRamayana Litpam-Indexator MANUAL.md](https://github.com/gasyoun/RussianRamayana/blob/main/Litpam-Indexator/docs/indesign-pipeline/MANUAL.md).
+- Source material: the per-folder readmes and — decisively — the actual
+  `redo*.sh` drivers across all 11 workspaces, surveyed by an Explore agent
+  (Fable 5 `claude-fable-5` session, 11-07-2026) with first-hand reads of
+  README/CLAUDE.md/issues. Two material doc-vs-code discrepancies found and
+  corrected in the manual instead of propagated:
+  1. `markup/abls/redo.sh` = 12 invocations (generator/applier separated),
+     not CLAUDE.md's 8 steps;
+  2. `verbs01/redo.sh` = 4 active commands with `mwverb.py`/`mwverbs1.py`
+     absent from that folder (they live in `ap57_verbs01/`), `mwverbs1.txt`
+     consumed from the sibling MWS repo, plus an undocumented Devanagari
+     output.
+- The apte_s2h byte-identical verification (05-07-2026) is inherited from the
+  README's recorded run, not re-executed here.
+
+## Ranked improvement backlog
+
+| # | Item | Status |
+|---|---|---|
+| 1 | Re-point [issues/issue29/redo_new.sh](https://github.com/sanskrit-lexicon/AP90/blob/master/issues/issue29/redo_new.sh) to AP90 (it still `cd`s into the AP repo and regenerates dict `ap`) and finish the cologne + csl-lslink delivery TODOs | open |
+| 2 | Fix [CLAUDE.md](https://github.com/sanskrit-lexicon/AP90/blob/master/CLAUDE.md)'s abls and verbs01 step lists to match the real `redo.sh` files, and point it at this manual | open |
+| 3 | Triage [andhrabharati/ap90ab_v2_suggest.txt](https://github.com/sanskrit-lexicon/AP90/blob/master/andhrabharati/ap90ab_v2_suggest.txt) — the unapplied abbreviation-normalization TODO list (apply, or record won't-fix) | open |
+| 4 | Live-verify the two re-runnable verb pipelines against current siblings and record fresh counts (apte_s2h already verified) | open |
+| 5 | Work the review pools left by hyphen_eng: 97 open `hyphen_questions.txt` cases + the ~3,000 `type=false` spell-check flags | open |
+| 6 | Clean cosmetic defects: abls `redo.sh` stale echo, hyphen_deva readme `changes_0b.txt` misspelling, issue26 readme duplicated-argument typo, committed `apte_s2h/__pycache__` | open |
+
+## Known limitations
+
+- **Transcription-verified, not re-executed** (except apte_s2h, inherited):
+  the campaigns are commit-pinned, already landed, and mutate the sibling
+  csl-orig tree. Backlog #4 upgrades the verb pipelines.
+- issue26/issue29 are open campaigns — the manual describes their state as of
+  11-07-2026; their folders' readmes remain the running logs.
+- The three coexisting path conventions are remapped descriptively, not
+  fixed; parameterization is upstream work in each folder.
+
+## Related documents
+
+- [README.md](https://github.com/sanskrit-lexicon/AP90/blob/master/README.md) — repo overview + the verified apte_s2h usage example
+- [CLAUDE.md](https://github.com/sanskrit-lexicon/AP90/blob/master/CLAUDE.md) — code contract (with the two idealized lists this manual corrects)
+- [DATA_DICTIONARY.md](https://github.com/sanskrit-lexicon/AP90/blob/master/DATA_DICTIONARY.md) — minimal tag table
+- [csl-corrections correction workflow](https://github.com/sanskrit-lexicon/csl-corrections/blob/main/docs/correction-workflow.md) — the canonical delivery procedure
+- Sibling census-batch manuals: [AP](https://github.com/sanskrit-lexicon/AP/blob/main/docs/PIPELINE_MANUAL.md) · [PWK](https://github.com/sanskrit-lexicon/PWK/blob/main/docs/PIPELINE_MANUAL.md) · [AMAR](https://github.com/sanskrit-lexicon/AMAR/blob/main/docs/CONVERSION_MANUAL.md)
+
+## Revision history
+
+| Date | Change | By |
+|---|---|---|
+| 11-07-2026 | Initial manual + this metadoc authored (H523); 11 workspaces surveyed (1 Explore agent + first-hand README/CLAUDE/issue reads); 2 doc-vs-code discrepancies corrected, 8 traps recorded | Fable 5 (`claude-fable-5`) |
+
+_Dr. Mārcis Gasūns_

--- a/docs/PIPELINE_MANUAL.meta.md
+++ b/docs/PIPELINE_MANUAL.meta.md
@@ -67,6 +67,48 @@ files**, correcting the two idealized step lists in CLAUDE.md/README.
 - The three coexisting path conventions are remapped descriptively, not
   fixed; parameterization is upstream work in each folder.
 
+## Intended use / known misuse
+
+- **For:** onboarding a new operator/contributor to run or re-run an AP90
+  pipeline (markup rounds, hyphenation, either verb pipeline, transcoding, or
+  the two open issue campaigns) from the *actual* `redo.sh` drivers, and for
+  a maintainer or historian who needs the corrected step counts, the traps
+  appendix, or the commit-hash chaining order between campaigns.
+- **Known/likely misuse:**
+  - Treating the manual as a substitute for CLAUDE.md's code contract — it
+    corrects two step lists but does not replace CLAUDE.md's role for AI/code
+    sessions.
+  - Assuming the transcription-verified campaigns (all but apte_s2h) were
+    re-executed on 11-07-2026 — they were read and reconciled against the
+    scripts, not re-run; counts are inherited, not fresh (backlog #4).
+  - Reproducing a historical campaign against the *current* csl-orig HEAD
+    instead of its own pinned start commit — the hyphen_deva → abls → abls1
+    chaining only holds against each campaign's recorded commit.
+  - Using this manual as evidence that issue26/issue29 are closed — both are
+    open campaigns; the manual is a snapshot of their 11-07-2026 state, not
+    their live log (that's each folder's own readme).
+
+## Maintenance & sunset plan
+
+- **Owner:** the AP90 repo itself (`sanskrit-lexicon/AP90`), specifically
+  whoever next touches the markup/hyphen/verb tooling or works issue26/issue29
+  — there is no dedicated bot or scheduled job keeping this manual in sync.
+  Drift is caught opportunistically (a session editing a `redo.sh` should
+  update the matching manual section) or during a future census-batch sweep
+  like the one that authored it (H501–H531).
+- **Sunset trigger:** this manual is retired/superseded if AP90's pipelines
+  are consolidated into the org-wide Cologne tooling runbook (referenced from
+  the org `CLAUDE.md`) such that a per-repo operator manual becomes redundant,
+  or if the repo itself is archived. Until then it stays `active`.
+- **Archived/ended looks like:** the manual file moved under an `archive/`
+  folder (or the repo itself archived on GitHub) with a pointer left in
+  CLAUDE.md/README to wherever the operating knowledge lives instead, and this
+  metadoc's Deprecation status flipped accordingly.
+
+## Deprecation status
+
+`active`
+
 ## Related documents
 
 - [README.md](https://github.com/sanskrit-lexicon/AP90/blob/master/README.md) — repo overview + the verified apte_s2h usage example
@@ -80,5 +122,6 @@ files**, correcting the two idealized step lists in CLAUDE.md/README.
 | Date | Change | By |
 |---|---|---|
 | 11-07-2026 | Initial manual + this metadoc authored (H523); 11 workspaces surveyed (1 Explore agent + first-hand README/CLAUDE/issue reads); 2 doc-vs-code discrepancies corrected, 8 traps recorded | Fable 5 (`claude-fable-5`) |
+| 11-07-2026 | template v2 backfill (H663) | Sonnet 5 (`claude-sonnet-5`) |
 
 _Dr. Mārcis Gasūns_

--- a/index.html
+++ b/index.html
@@ -1,0 +1,104 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Apte's Sanskrit-English Dictionary (AP90) · Cologne Digital Sanskrit Lexicon</title>
+<meta name="description" content="Apte&#x27;s original Sanskrit-English Dictionary of 1890 &#x2014; an accessible, widely used reference later revised and expanded in 1957.">
+<link rel="canonical" href="https://sanskrit-lexicon.github.io/AP90/">
+<meta name="theme-color" content="#1f78b4">
+<meta name="author" content="Vaman Shivram Apte">
+<meta name="robots" content="index,follow">
+<meta property="og:type" content="website">
+<meta property="og:site_name" content="Cologne Digital Sanskrit Lexicon">
+<meta property="og:locale" content="en">
+<meta property="og:title" content="Apte's Sanskrit-English Dictionary (AP90)">
+<meta property="og:description" content="Apte&#x27;s original Sanskrit-English Dictionary of 1890 &#x2014; an accessible, widely used reference later revised and expanded in 1957.">
+<meta property="og:url" content="https://sanskrit-lexicon.github.io/AP90/">
+<meta property="og:image" content="https://sanskrit-lexicon.github.io/cdsl-card.png">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta property="og:image:alt" content="Cologne Digital Sanskrit Lexicon">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Apte's Sanskrit-English Dictionary (AP90)">
+<meta name="twitter:description" content="Apte&#x27;s original Sanskrit-English Dictionary of 1890 &#x2014; an accessible, widely used reference later revised and expanded in 1957.">
+<meta name="twitter:image" content="https://sanskrit-lexicon.github.io/cdsl-card.png">
+<script type="application/ld+json">
+{"@context":"https://schema.org","@type":"Book","name":"Apte's Sanskrit-English Dictionary","alternateName":"AP90","inLanguage":"sa","publisher":{"@type":"Organization","name":"Cologne Digital Sanskrit Lexicon"},"url":"https://sanskrit-lexicon.github.io/AP90/","isAccessibleForFree":true,"license":"https://creativecommons.org/licenses/by-sa/4.0/"}
+</script>
+<style>
+  :root { --ink:#1b2a38; --muted:#5a6b7a; --accent:#1f78b4; --bg:#f7f9fb; --card:#fff; --line:#e2e8ee; }
+  * { box-sizing:border-box; }
+  html { -webkit-text-size-adjust:100%; }
+  body { margin:0; font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;
+    color:var(--ink); background:var(--bg); line-height:1.6; }
+  a { color:var(--accent); }
+  .wrap { max-width:760px; margin:0 auto; padding:0 20px; }
+  header.top { border-bottom:1px solid var(--line); background:var(--card); }
+  header.top .wrap { display:flex; align-items:center; gap:.5rem; height:56px; font-size:.95rem; }
+  header.top a { color:var(--muted); text-decoration:none; font-weight:600; }
+  .hero { background:linear-gradient(160deg,#1e2f40,#2d4e6e); color:#f4f7fa; padding:56px 0 48px; }
+  .badge { display:inline-block; font-weight:700; letter-spacing:.08em; font-size:.8rem;
+    background:rgba(255,255,255,.14); color:#cfe3f2; padding:.35rem .7rem; border-radius:999px; }
+  .hero h1 { font-family:Georgia,"Times New Roman",serif; font-size:2.1rem; line-height:1.2; margin:.9rem 0 .5rem; }
+  .hero .sub { color:#b7cddf; font-size:1.05rem; margin:0 0 1.2rem; }
+  .hero p.desc { color:#dbe6f0; margin:0; max-width:62ch; }
+  .cta { display:flex; flex-wrap:wrap; gap:.7rem; margin:1.6rem 0 0; }
+  .btn { display:inline-block; padding:.7rem 1.1rem; border-radius:8px; text-decoration:none; font-weight:600; font-size:.95rem; }
+  .btn.primary { background:#4aa3df; color:#0b1b28; }
+  .btn.ghost { background:rgba(255,255,255,.10); color:#eaf2f8; border:1px solid rgba(255,255,255,.25); }
+  main { padding:40px 0 20px; }
+  .facts { display:grid; grid-template-columns:repeat(auto-fit,minmax(150px,1fr)); gap:1px;
+    background:var(--line); border:1px solid var(--line); border-radius:10px; overflow:hidden; margin:0 0 28px; }
+  .facts div { background:var(--card); padding:14px 16px; }
+  .facts dt { font-size:.72rem; text-transform:uppercase; letter-spacing:.06em; color:var(--muted); }
+  .facts dd { margin:.2rem 0 0; font-weight:600; }
+  section h2 { font-size:1.15rem; margin:1.8rem 0 .5rem; }
+  .note { color:var(--muted); font-size:.95rem; }
+  footer { border-top:1px solid var(--line); background:var(--card); margin-top:32px; }
+  footer .wrap { padding:22px 20px; color:var(--muted); font-size:.9rem; }
+  footer a { color:var(--muted); }
+  @media (max-width:520px) { .hero h1 { font-size:1.7rem; } }
+</style>
+</head>
+<body>
+<header class="top"><div class="wrap"><a href="https://sanskrit-lexicon.github.io/">← Cologne Digital Sanskrit Lexicon</a></div></header>
+<div class="hero"><div class="wrap">
+  <span class="badge">AP90</span>
+  <h1>Apte's Sanskrit-English Dictionary</h1>
+  <p class="sub">Vaman Shivram Apte · Poona, 1890</p>
+  <p class="desc">Apte's original Sanskrit-English Dictionary of 1890 — an accessible, widely used reference later revised and expanded in 1957.</p>
+  <div class="cta">
+    <a class="btn primary" href="https://www.sanskrit-lexicon.uni-koeln.de/scans/AP90Scan/2020/web/webtc/indexcaller.php">Browse the dictionary →</a>
+    <a class="btn ghost" href="https://github.com/sanskrit-lexicon/AP90">Source &amp; corrections (GitHub)</a>
+    <a class="btn ghost" href="https://sanskrit-lexicon.github.io/">All dictionaries</a>
+  </div>
+</div></div>
+<main><div class="wrap">
+  <dl class="facts">
+    <div><dt>Abbreviation</dt><dd>AP90</dd></div>
+    <div><dt>Direction</dt><dd>Sanskrit → English</dd></div>
+    <div><dt>First published</dt><dd>1890</dd></div>
+    <div><dt>Digitised by</dt><dd>CDSL</dd></div>
+  </dl>
+  <section>
+    <h2>About this edition</h2>
+    <p class="note">This is the digital home of the <strong>Apte's Sanskrit-English Dictionary</strong> (AP90) within the
+    <a href="https://www.sanskrit-lexicon.uni-koeln.de/">Cologne Digital Sanskrit Lexicon</a> (CDSL),
+    a volunteer project that digitises, corrects, and openly publishes the foundational Sanskrit
+    dictionaries as citable, reproducible data. Corrections are tracked as change files in this
+    repository; the searchable text is served on the Cologne site.</p>
+    <h2>Use &amp; reuse</h2>
+    <p class="note">Dictionary data is released under
+    <a href="https://creativecommons.org/licenses/by-sa/4.0/">CC BY-SA 4.0</a> unless noted otherwise.
+    Report errors or contribute corrections via the
+    <a href="https://github.com/sanskrit-lexicon/AP90/issues">GitHub issue tracker</a>.</p>
+  </section>
+</div></main>
+<footer><div class="wrap">
+  Part of the <a href="https://sanskrit-lexicon.github.io/">Cologne Digital Sanskrit Lexicon</a> ·
+  <a href="https://www.sanskrit-lexicon.uni-koeln.de/">sanskrit-lexicon.uni-koeln.de</a> ·
+  <a href="https://github.com/sanskrit-lexicon">GitHub</a>
+</div></footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Adds the three template-v2 metadoc sections (H663) to `docs/PIPELINE_MANUAL.meta.md`: Intended use / known misuse, Maintenance & sunset plan, Deprecation status (`active`).
- Content drawn from reading `docs/PIPELINE_MANUAL.md` and the existing metadoc — not boilerplate.
- Appends one revision-history row.

## Test plan
- [ ] Human review of the new sections' accuracy