### PR TITLE
fix: repair 4 broken link(s) (org-wide link audit)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,11 +2,11 @@
 
 AP90 is part of the [Sanskrit Lexicon](https://github.com/sanskrit-lexicon) project — corrections and enhancements for the Cologne digitisation of *Apte Sanskrit–English Dictionary of 1890*.
 
-> Inherits the [Sanskrit Lexicon org-wide contribution standard](https://github.com/sanskrit-lexicon/COLOGNE/blob/master/CONTRIBUTING.md). This file documents anything **repo-specific** on top of it.
+> Inherits the [Sanskrit Lexicon org-wide contribution standard](https://github.com/sanskrit-lexicon/COLOGNE/blob/main/CONTRIBUTING.md). This file documents anything **repo-specific** on top of it.
 
 ## Reporting issues
 
-Use the issue templates in `.github/ISSUE_TEMPLATE/`. Each issue gets exactly one **type** label, one **severity** label, and one **milestone** — see the [org-wide taxonomy](https://github.com/sanskrit-lexicon/COLOGNE/blob/master/CONTRIBUTING.md#issue-taxonomy--dictionary-repos).
+Use the issue templates in `.github/ISSUE_TEMPLATE/`. Each issue gets exactly one **type** label, one **severity** label, and one **milestone** — see the [org-wide taxonomy](https://github.com/sanskrit-lexicon/COLOGNE/blob/main/CONTRIBUTING.md#issue-taxonomy--dictionary-repos).
 
 Before opening:
 1. Search existing issues (including closed) for similar patterns.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ literary-source-abbreviation transcoding pipeline — part of the
 
 ## Why this repo exists
 
-The canonical source text ([`ap90.txt`](https://github.com/sanskrit-lexicon/csl-orig/blob/master/v02/ap90/ap90.txt))
+The canonical source text ([`ap90.txt`](https://github.com/sanskrit-lexicon/csl-orig/blob/main/v02/ap90/ap90.txt))
 lives in the sibling `csl-orig` repo and is never edited directly. This repo
 is where the actual correction and enrichment engineering happens: markup
 normalization pipelines (five sequential `prep*.py` steps for `<ls>`


### PR DESCRIPTION
Auto-fixed broken links found by an org-wide link audit (unique renamed-file matches, wrong-branch blob URLs). Landed via a dedicated branch/worktree rather than the branch that happened to be checked out, to keep this scoped separately from other in-flight work.